### PR TITLE
Update Dockerfile to ignore scripts during serve install

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 
 RUN npm install
 
-RUN npm i -g serve
+RUN npm i -g --ignore-scripts serve
 
 COPY . .
 


### PR DESCRIPTION
When installing dependencies, package managers like npm will automatically execute shell scripts distributed along with the source code. Post-install scripts, for example, are a common way to execute malicious code at install time whenever a package is compromised.