### PR TITLE
refactor: unify proficiency types into single generic base class

### DIFF
--- a/server/src/KanjiKa.Application/Interfaces/ILessonRepository.cs
+++ b/server/src/KanjiKa.Application/Interfaces/ILessonRepository.cs
@@ -12,7 +12,7 @@ public interface ILessonRepository
 
     Task<int> CountLessonsCompletedTodayAsync(int userId);
 
-    Task<List<Character>> GetNewCharactersAsync(List<Proficiency> proficiencies);
+    Task<List<Character>> GetNewCharactersAsync(List<KanaProficiency> proficiencies);
 
     Task<int> CountNewCharactersAsync(List<int> learnedCharacterIds);
 
@@ -20,15 +20,15 @@ public interface ILessonRepository
 
     Task<Character?> GetCharacterBySymbolAsync(string symbol);
 
-    Task<Proficiency?> GetProficiencyAsync(int userId, int characterId);
+    Task<KanaProficiency?> GetProficiencyAsync(int userId, int characterId);
 
-    Task AddProficiencyAsync(Proficiency proficiency);
+    Task AddProficiencyAsync(KanaProficiency proficiency);
 
     Task AddLessonCompletionAsync(LessonCompletion completion);
 
     Task<List<LessonCompletion>> GetLessonCompletionsByUserAsync(int userId);
 
-    Task<List<Proficiency>> GetDueReviewsAsync(int userId);
+    Task<List<KanaProficiency>> GetDueReviewsAsync(int userId);
 
     Task SaveChangesAsync();
 }

--- a/server/src/KanjiKa.Application/Interfaces/ILessonService.cs
+++ b/server/src/KanjiKa.Application/Interfaces/ILessonService.cs
@@ -9,7 +9,7 @@ public interface ILessonService
 
     Task<IEnumerable<LessonDto>> GetLessonsAsync(int userId, int pageIndex, int pageSize);
 
-    Task<Proficiency> LearnLessonAsync(int userId, int characterId);
+    Task<KanaProficiency> LearnLessonAsync(int userId, int characterId);
 
     Task<LessonReviewsCountDto> GetLessonReviewsCountAsync(int userId);
 

--- a/server/src/KanjiKa.Application/Services/AdminService.cs
+++ b/server/src/KanjiKa.Application/Services/AdminService.cs
@@ -46,14 +46,14 @@ public class AdminService : IAdminService
             Username = user.Username,
             Role = user.Role,
             MustChangePassword = user.MustChangePassword,
-            ProficiencyCount = user.Proficiencies.Count,
+            ProficiencyCount = user.KanaProficiencies.Count,
             LessonCompletionCount = user.LessonCompletions.Count,
-            Proficiencies = user.Proficiencies.Select(p => new ProficiencySummaryDto
+            Proficiencies = user.KanaProficiencies.Select(p => new ProficiencySummaryDto
             {
                 CharacterId = p.CharacterId,
                 CharacterSymbol = p.Character?.Symbol ?? "",
                 LearnedAt = p.LearnedAt,
-                LastPracticed = p.LastPracticed
+                LastPracticed = p.LastPracticedAt
             }).ToList(),
             LessonCompletions = user.LessonCompletions.Select(lc => new LessonCompletionSummaryDto
             {

--- a/server/src/KanjiKa.Application/Services/KanaService.cs
+++ b/server/src/KanjiKa.Application/Services/KanaService.cs
@@ -1,5 +1,6 @@
 using KanjiKa.Application.DTOs.Kana;
 using KanjiKa.Application.Interfaces;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Users;
 
@@ -42,7 +43,7 @@ public class KanaService : IKanaService
             throw new ArgumentException($"User with id {userId} not found");
         }
 
-        Proficiency? userProficiency = user.Proficiencies
+        KanaProficiency? userProficiency = user.KanaProficiencies
             .FirstOrDefault(p => p.CharacterId == kanaCharacter.Id);
         int level = userProficiency?.Level ?? 0;
         SrsStage srsStage = userProficiency?.SrsStage ?? SrsStage.Locked;
@@ -80,7 +81,7 @@ public class KanaService : IKanaService
             Character = c.Symbol,
             Romanization = c.Romanization,
             Type = c.Type,
-            Proficiency = user.Proficiencies
+            Proficiency = user.KanaProficiencies
                 .FirstOrDefault(p => p.CharacterId == c.Id)?
                 .Level ?? 0
         };

--- a/server/src/KanjiKa.Application/Services/KanjiService.cs
+++ b/server/src/KanjiKa.Application/Services/KanjiService.cs
@@ -1,7 +1,7 @@
 using KanjiKa.Application.DTOs;
 using KanjiKa.Application.DTOs.Kanji;
 using KanjiKa.Application.Interfaces;
-using KanjiKa.Domain.Entities.Kana;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kanji;
 
 namespace KanjiKa.Application.Services;

--- a/server/src/KanjiKa.Application/Services/LessonService.cs
+++ b/server/src/KanjiKa.Application/Services/LessonService.cs
@@ -1,5 +1,6 @@
 using KanjiKa.Application.DTOs.Learning;
 using KanjiKa.Application.Interfaces;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Learning;
 using KanjiKa.Domain.Entities.Users;
@@ -25,7 +26,7 @@ public class LessonService : ILessonService
         int lessonsLearnedToday = await _repo.CountLessonsCompletedTodayAsync(userId);
         int count = LessonsPerDayCount - lessonsLearnedToday;
 
-        List<int> learnedCharacterIds = user.Proficiencies.Select(p => p.CharacterId).ToList();
+        List<int> learnedCharacterIds = user.KanaProficiencies.Select(p => p.CharacterId).ToList();
         int unlearnedCount = await _repo.CountNewCharactersAsync(learnedCharacterIds);
 
         return new LessonsCountDto
@@ -53,7 +54,7 @@ public class LessonService : ILessonService
             return [];
 
         int takeSize = Math.Min(count, pageSize);
-        IEnumerable<LessonDto> lessons = (await _repo.GetNewCharactersAsync(user.Proficiencies))
+        IEnumerable<LessonDto> lessons = (await _repo.GetNewCharactersAsync(user.KanaProficiencies))
             .Skip(pageIndex * takeSize)
             .Take(takeSize)
             .Select(MapToLessonDto);
@@ -61,7 +62,7 @@ public class LessonService : ILessonService
         return lessons;
     }
 
-    public async Task<Proficiency> LearnLessonAsync(int userId, int characterId)
+    public async Task<KanaProficiency> LearnLessonAsync(int userId, int characterId)
     {
         User? user = await _repo.GetUserAsync(userId);
         if (user == null)
@@ -71,11 +72,11 @@ public class LessonService : ILessonService
         if (character == null)
             throw new ArgumentException("Character not found", nameof(characterId));
 
-        Proficiency? existingProficiency = await _repo.GetProficiencyAsync(userId, characterId);
+        KanaProficiency? existingProficiency = await _repo.GetProficiencyAsync(userId, characterId);
         if (existingProficiency != null)
             throw new ArgumentException("Character already learned", nameof(characterId));
 
-        var proficiency = new Proficiency
+        var proficiency = new KanaProficiency
         {
             UserId = user.Id,
             CharacterId = character.Id,
@@ -106,7 +107,7 @@ public class LessonService : ILessonService
 
     public async Task<IEnumerable<LessonReviewDto>> GetLessonReviewsAsync(int userId)
     {
-        List<Proficiency> dueReviews = await _repo.GetDueReviewsAsync(userId);
+        List<KanaProficiency> dueReviews = await _repo.GetDueReviewsAsync(userId);
         List<LessonReviewDto> ordered = dueReviews
             .OrderBy(p => p.NextReviewDate)
             .Select(p => new LessonReviewDto
@@ -124,7 +125,7 @@ public class LessonService : ILessonService
         if (character == null)
             throw new ArgumentException("Character not found", nameof(answer));
 
-        Proficiency proficiency = await _repo.GetProficiencyAsync(userId, character.Id)
+        KanaProficiency proficiency = await _repo.GetProficiencyAsync(userId, character.Id)
                                   ?? await LearnLessonAsync(userId, character.Id);
 
         bool isCorrect = answer.Answer == character.Romanization;
@@ -145,7 +146,7 @@ public class LessonService : ILessonService
 
     public async Task<IEnumerable<WritingReviewDto>> GetWritingReviewsAsync(int userId)
     {
-        List<Proficiency> dueReviews = await _repo.GetDueReviewsAsync(userId);
+        List<KanaProficiency> dueReviews = await _repo.GetDueReviewsAsync(userId);
         List<WritingReviewDto> ordered = dueReviews
             .OrderBy(p => p.NextReviewDate)
             .Select(p => new WritingReviewDto
@@ -165,7 +166,7 @@ public class LessonService : ILessonService
         if (character == null)
             throw new ArgumentException("Character not found", nameof(answer));
 
-        Proficiency? proficiency = await _repo.GetProficiencyAsync(userId, character.Id);
+        KanaProficiency? proficiency = await _repo.GetProficiencyAsync(userId, character.Id);
         if (proficiency is null)
             throw new ArgumentException("No proficiency record found for this character.", nameof(answer));
 
@@ -181,11 +182,11 @@ public class LessonService : ILessonService
 
     private async Task<int> GetDueReviewsCountAsync(int userId)
     {
-        List<Proficiency> dueReviews = await _repo.GetDueReviewsAsync(userId);
+        List<KanaProficiency> dueReviews = await _repo.GetDueReviewsAsync(userId);
         return dueReviews.Count;
     }
 
-    private static LessonReviewAnswerResultDto BuildReviewResult(bool isCorrect, string correctAnswer, Proficiency proficiency)
+    private static LessonReviewAnswerResultDto BuildReviewResult(bool isCorrect, string correctAnswer, KanaProficiency proficiency)
     {
         return new LessonReviewAnswerResultDto
         {

--- a/server/src/KanjiKa.Application/Services/ReadingService.cs
+++ b/server/src/KanjiKa.Application/Services/ReadingService.cs
@@ -97,7 +97,7 @@ public class ReadingService : IReadingService
             Score = score,
             AttemptCount = (existing?.AttemptCount ?? 0) + 1,
             IsPassed = isPassed,
-            LastAttemptAt = DateTimeOffset.UtcNow
+            LastPracticedAt = DateTimeOffset.UtcNow
         };
 
         await _readingRepository.UpsertProficiencyAsync(proficiency);

--- a/server/src/KanjiKa.Data/KanjiKaDbContext.cs
+++ b/server/src/KanjiKa.Data/KanjiKaDbContext.cs
@@ -16,7 +16,7 @@ public class KanjiKaDbContext : DbContext
 
     public DbSet<User> Users { get; set; }
     public DbSet<UserSettings> UserSettings { get; set; }
-    public DbSet<Proficiency> Proficiencies { get; set; }
+    public DbSet<KanaProficiency> KanaProficiencies { get; set; }
     public DbSet<LessonCompletion> LessonCompletions { get; set; }
     public DbSet<Character> Characters { get; set; }
     public DbSet<Example> Examples { get; set; }
@@ -54,7 +54,7 @@ public class KanjiKaDbContext : DbContext
             entity.HasIndex(u => u.Username).IsUnique();
             entity.HasIndex(u => u.ActivationToken)
                 .HasFilter("activation_token IS NOT NULL");
-            entity.HasMany(x => x.Proficiencies)
+            entity.HasMany(x => x.KanaProficiencies)
                 .WithOne(proficiency => proficiency.User)
                 .HasForeignKey(proficiency => proficiency.UserId);
             entity.HasMany(x => x.LessonCompletions)
@@ -69,9 +69,15 @@ public class KanjiKaDbContext : DbContext
             entity.HasKey(s => s.Id);
         });
 
-        modelBuilder.Entity<Proficiency>(entity => {
-            entity.HasKey(proficiency => new { proficiency.UserId, proficiency.CharacterId });
+        modelBuilder.Entity<KanaProficiency>(entity => {
+            entity.HasKey(p => p.Id);
+            entity.HasIndex(p => new { p.UserId, p.CharacterId }).IsUnique();
+            entity.Property(p => p.SrsStage).HasConversion<int>();
             entity.Ignore(p => p.Level);
+            entity.HasOne(p => p.Character)
+                .WithMany()
+                .HasForeignKey(p => p.CharacterId);
+            entity.Ignore(p => p.Content);
         });
 
         modelBuilder.Entity<LessonCompletion>(entity => {
@@ -104,6 +110,10 @@ public class KanjiKaDbContext : DbContext
             entity.HasKey(kp => kp.Id);
             entity.HasIndex(kp => new { kp.UserId, kp.KanjiId }).IsUnique();
             entity.Property(kp => kp.SrsStage).HasConversion<int>();
+            entity.HasOne(kp => kp.Kanji)
+                .WithMany()
+                .HasForeignKey(kp => kp.KanjiId);
+            entity.Ignore(kp => kp.Content);
         });
 
         modelBuilder.Entity<GrammarPoint>(entity => {
@@ -127,6 +137,11 @@ public class KanjiKaDbContext : DbContext
         modelBuilder.Entity<GrammarProficiency>(entity => {
             entity.HasKey(gp => gp.Id);
             entity.HasIndex(gp => new { gp.UserId, gp.GrammarPointId }).IsUnique();
+            entity.Property(gp => gp.SrsStage).HasConversion<int>();
+            entity.HasOne(gp => gp.GrammarPoint)
+                .WithMany()
+                .HasForeignKey(gp => gp.GrammarPointId);
+            entity.Ignore(gp => gp.Content);
         });
 
         modelBuilder.Entity<ReadingPassage>(entity => {
@@ -143,6 +158,11 @@ public class KanjiKaDbContext : DbContext
         modelBuilder.Entity<ReadingProficiency>(entity => {
             entity.HasKey(rp => rp.Id);
             entity.HasIndex(rp => new { rp.UserId, rp.ReadingPassageId }).IsUnique();
+            entity.Property(rp => rp.SrsStage).HasConversion<int>();
+            entity.HasOne(rp => rp.ReadingPassage)
+                .WithMany()
+                .HasForeignKey(rp => rp.ReadingPassageId);
+            entity.Ignore(rp => rp.Content);
         });
 
         modelBuilder.Entity<LearningUnit>(entity => {

--- a/server/src/KanjiKa.Data/Migrations/20260418223812_UnifyProficiencyHierarchy.Designer.cs
+++ b/server/src/KanjiKa.Data/Migrations/20260418223812_UnifyProficiencyHierarchy.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using KanjiKa.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace KanjiKa.Data.Migrations
 {
     [DbContext(typeof(KanjiKaDbContext))]
-    partial class KanjiKaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418223812_UnifyProficiencyHierarchy")]
+    partial class UnifyProficiencyHierarchy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/KanjiKa.Data/Migrations/20260418223812_UnifyProficiencyHierarchy.cs
+++ b/server/src/KanjiKa.Data/Migrations/20260418223812_UnifyProficiencyHierarchy.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace KanjiKa.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UnifyProficiencyHierarchy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "proficiencies");
+
+            migrationBuilder.RenameColumn(
+                name: "last_attempt_at",
+                table: "reading_proficiencies",
+                newName: "last_practiced_at");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "learned_at",
+                table: "reading_proficiencies",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "next_review_date",
+                table: "reading_proficiencies",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "srs_stage",
+                table: "reading_proficiencies",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "last_practiced_at",
+                table: "kanji_proficiencies",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "learned_at",
+                table: "grammar_proficiencies",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "next_review_date",
+                table: "grammar_proficiencies",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "srs_stage",
+                table: "grammar_proficiencies",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "kana_proficiencies",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    character_id = table.Column<int>(type: "integer", nullable: false),
+                    user_id = table.Column<int>(type: "integer", nullable: false),
+                    srs_stage = table.Column<int>(type: "integer", nullable: false),
+                    next_review_date = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    learned_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    last_practiced_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_kana_proficiencies", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_kana_proficiencies_characters_character_id",
+                        column: x => x.character_id,
+                        principalTable: "characters",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_kana_proficiencies_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_kana_proficiencies_character_id",
+                table: "kana_proficiencies",
+                column: "character_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_kana_proficiencies_user_id_character_id",
+                table: "kana_proficiencies",
+                columns: new[] { "user_id", "character_id" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "kana_proficiencies");
+
+            migrationBuilder.DropColumn(
+                name: "learned_at",
+                table: "reading_proficiencies");
+
+            migrationBuilder.DropColumn(
+                name: "next_review_date",
+                table: "reading_proficiencies");
+
+            migrationBuilder.DropColumn(
+                name: "srs_stage",
+                table: "reading_proficiencies");
+
+            migrationBuilder.DropColumn(
+                name: "last_practiced_at",
+                table: "kanji_proficiencies");
+
+            migrationBuilder.DropColumn(
+                name: "learned_at",
+                table: "grammar_proficiencies");
+
+            migrationBuilder.DropColumn(
+                name: "next_review_date",
+                table: "grammar_proficiencies");
+
+            migrationBuilder.DropColumn(
+                name: "srs_stage",
+                table: "grammar_proficiencies");
+
+            migrationBuilder.RenameColumn(
+                name: "last_practiced_at",
+                table: "reading_proficiencies",
+                newName: "last_attempt_at");
+
+            migrationBuilder.CreateTable(
+                name: "proficiencies",
+                columns: table => new
+                {
+                    user_id = table.Column<int>(type: "integer", nullable: false),
+                    character_id = table.Column<int>(type: "integer", nullable: false),
+                    id = table.Column<int>(type: "integer", nullable: false),
+                    last_practiced = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    learned_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    next_review_date = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    srs_stage = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_proficiencies", x => new { x.user_id, x.character_id });
+                    table.ForeignKey(
+                        name: "fk_proficiencies_characters_character_id",
+                        column: x => x.character_id,
+                        principalTable: "characters",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_proficiencies_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_proficiencies_character_id",
+                table: "proficiencies",
+                column: "character_id");
+        }
+    }
+}

--- a/server/src/KanjiKa.Data/Repositories/KanaRepository.cs
+++ b/server/src/KanjiKa.Data/Repositories/KanaRepository.cs
@@ -17,7 +17,7 @@ public class KanaRepository : IKanaRepository
     public async Task<User?> GetUserWithProficienciesAsync(int userId)
     {
         return await _db.Users
-            .Include(x => x.Proficiencies)
+            .Include(x => x.KanaProficiencies)
             .AsNoTracking()
             .FirstOrDefaultAsync(u => u.Id == userId);
     }

--- a/server/src/KanjiKa.Data/Repositories/LessonRepository.cs
+++ b/server/src/KanjiKa.Data/Repositories/LessonRepository.cs
@@ -1,4 +1,5 @@
-﻿using KanjiKa.Domain.Entities.Kana;
+using KanjiKa.Domain.Entities.Common;
+using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Learning;
 using KanjiKa.Domain.Entities.Users;
 using KanjiKa.Application.Interfaces;
@@ -23,7 +24,7 @@ public class LessonRepository : ILessonRepository
     public async Task<User?> GetUserWithProficienciesAsync(int userId)
     {
         return await _db.Users
-            .Include(u => u.Proficiencies)
+            .Include(u => u.KanaProficiencies)
             .AsNoTracking()
             .FirstOrDefaultAsync(u => u.Id == userId);
     }
@@ -34,7 +35,7 @@ public class LessonRepository : ILessonRepository
         return await _db.LessonCompletions.CountAsync(lc => lc.UserId == userId && lc.CompletionDate.Date == today.Date);
     }
 
-    public async Task<List<Character>> GetNewCharactersAsync(List<Proficiency> proficiencies)
+    public async Task<List<Character>> GetNewCharactersAsync(List<KanaProficiency> proficiencies)
     {
         if (proficiencies.Count == 0)
             return await _db.Characters.ToListAsync();
@@ -65,14 +66,14 @@ public class LessonRepository : ILessonRepository
         return await _db.Characters.FirstOrDefaultAsync(c => c.Symbol == symbol);
     }
 
-    public async Task<Proficiency?> GetProficiencyAsync(int userId, int characterId)
+    public async Task<KanaProficiency?> GetProficiencyAsync(int userId, int characterId)
     {
-        return await _db.Proficiencies.FirstOrDefaultAsync(p => p.UserId == userId && p.CharacterId == characterId);
+        return await _db.KanaProficiencies.FirstOrDefaultAsync(p => p.UserId == userId && p.CharacterId == characterId);
     }
 
-    public async Task AddProficiencyAsync(Proficiency proficiency)
+    public async Task AddProficiencyAsync(KanaProficiency proficiency)
     {
-        await _db.Proficiencies.AddAsync(proficiency);
+        await _db.KanaProficiencies.AddAsync(proficiency);
     }
 
     public async Task AddLessonCompletionAsync(LessonCompletion completion)
@@ -87,10 +88,10 @@ public class LessonRepository : ILessonRepository
             .Where(lc => lc.UserId == userId).ToListAsync();
     }
 
-    public async Task<List<Proficiency>> GetDueReviewsAsync(int userId)
+    public async Task<List<KanaProficiency>> GetDueReviewsAsync(int userId)
     {
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        return await _db.Proficiencies
+        return await _db.KanaProficiencies
             .Include(p => p.Character)
             .Where(p => p.UserId == userId
                         && p.NextReviewDate != null

--- a/server/src/KanjiKa.Data/Repositories/ReadingRepository.cs
+++ b/server/src/KanjiKa.Data/Repositories/ReadingRepository.cs
@@ -51,7 +51,7 @@ public class ReadingRepository : IReadingRepository
             existing.Score = proficiency.Score;
             existing.AttemptCount = proficiency.AttemptCount;
             existing.IsPassed = proficiency.IsPassed;
-            existing.LastAttemptAt = proficiency.LastAttemptAt;
+            existing.LastPracticedAt = proficiency.LastPracticedAt;
         }
     }
 

--- a/server/src/KanjiKa.Data/Repositories/UserRepository.cs
+++ b/server/src/KanjiKa.Data/Repositories/UserRepository.cs
@@ -37,7 +37,7 @@ public class UserRepository : IUserRepository
     public Task<User?> GetByIdWithStatsAsync(int id)
     {
         return _db.Users
-            .Include(u => u.Proficiencies).ThenInclude(p => p.Character)
+            .Include(u => u.KanaProficiencies).ThenInclude(p => p.Character)
             .Include(u => u.LessonCompletions).ThenInclude(lc => lc.Character)
             .FirstOrDefaultAsync(u => u.Id == id);
     }
@@ -62,7 +62,7 @@ public class UserRepository : IUserRepository
                 Username = u.Username,
                 Role = u.Role,
                 MustChangePassword = u.MustChangePassword,
-                ProficiencyCount = u.Proficiencies.Count(),
+                ProficiencyCount = u.KanaProficiencies.Count(),
                 LessonCompletionCount = u.LessonCompletions.Count()
             })
             .ToListAsync();

--- a/server/src/KanjiKa.Data/Seeders/DevelopmentDataSeeder.cs
+++ b/server/src/KanjiKa.Data/Seeders/DevelopmentDataSeeder.cs
@@ -1,3 +1,4 @@
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Grammar;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Kanji;
@@ -53,9 +54,9 @@ public class DevelopmentDataSeeder : ProductionDataSeeder
             SrsStage.Apprentice4, SrsStage.Guru1
         };
         List<Character> midCharacters = characters.Take(30).ToList();
-        List<Proficiency> midProficiencies = midCharacters.Select((c, i) => {
+        List<KanaProficiency> midProficiencies = midCharacters.Select((c, i) => {
             SrsStage stage = midStages[i % midStages.Length];
-            return new Proficiency
+            return new KanaProficiency
             {
                 UserId = midLearner.Id,
                 CharacterId = c.Id,
@@ -69,7 +70,7 @@ public class DevelopmentDataSeeder : ProductionDataSeeder
             CharacterId = c.Id,
             CompletionDate = DateTimeOffset.UtcNow
         }).ToList();
-        await Context.Proficiencies.AddRangeAsync(midProficiencies);
+        await Context.KanaProficiencies.AddRangeAsync(midProficiencies);
         await Context.LessonCompletions.AddRangeAsync(midLessons);
         await Context.SaveChangesAsync();
 
@@ -78,7 +79,7 @@ public class DevelopmentDataSeeder : ProductionDataSeeder
         await Context.Users.AddAsync(advanced);
         await Context.SaveChangesAsync();
 
-        List<Proficiency> advancedProficiencies = characters.Select(c => new Proficiency
+        List<KanaProficiency> advancedProficiencies = characters.Select(c => new KanaProficiency
         {
             UserId = advanced.Id,
             CharacterId = c.Id,
@@ -91,7 +92,7 @@ public class DevelopmentDataSeeder : ProductionDataSeeder
             CharacterId = c.Id,
             CompletionDate = DateTimeOffset.UtcNow
         }).ToList();
-        await Context.Proficiencies.AddRangeAsync(advancedProficiencies);
+        await Context.KanaProficiencies.AddRangeAsync(advancedProficiencies);
         await Context.LessonCompletions.AddRangeAsync(advancedLessons);
         await Context.SaveChangesAsync();
 
@@ -104,7 +105,7 @@ public class DevelopmentDataSeeder : ProductionDataSeeder
         List<Character> reviewerCharacters = characters.Take(40).ToList();
         List<Kanji> reviewerKanjis = kanjis.Take(10).ToList();
 
-        List<Proficiency> reviewerProficiencies = reviewerCharacters.Select(c => new Proficiency
+        List<KanaProficiency> reviewerProficiencies = reviewerCharacters.Select(c => new KanaProficiency
         {
             UserId = reviewer.Id,
             CharacterId = c.Id,
@@ -125,7 +126,7 @@ public class DevelopmentDataSeeder : ProductionDataSeeder
             NextReviewDate = reviewerDueDate
         }).ToList();
 
-        await Context.Proficiencies.AddRangeAsync(reviewerProficiencies);
+        await Context.KanaProficiencies.AddRangeAsync(reviewerProficiencies);
         await Context.LessonCompletions.AddRangeAsync(reviewerLessons);
         await Context.KanjiProficiencies.AddRangeAsync(reviewerKanjiProficiencies);
         await Context.SaveChangesAsync();

--- a/server/src/KanjiKa.Domain/Entities/Common/Proficiency.cs
+++ b/server/src/KanjiKa.Domain/Entities/Common/Proficiency.cs
@@ -1,34 +1,32 @@
 using KanjiKa.Domain.Entities.Users;
 
-namespace KanjiKa.Domain.Entities.Kana;
+namespace KanjiKa.Domain.Entities.Common;
 
-public class Proficiency
+public abstract class Proficiency<TContent> where TContent : class
 {
-    public int Id { get; init; }
-    public int UserId { get; init; }
-    public User? User { get; init; }
-    public int CharacterId { get; init; }
-    public Character? Character { get; init; }
+    public int Id { get; set; }
+    public int UserId { get; set; }
+    public User? User { get; set; }
+    public TContent? Content { get; set; }
 
     public SrsStage SrsStage { get; set; } = SrsStage.Apprentice1;
     public DateTimeOffset? NextReviewDate { get; set; }
     public DateTimeOffset LearnedAt { get; init; } = DateTimeOffset.UtcNow;
-    public DateTimeOffset LastPracticed { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset LastPracticedAt { get; set; } = DateTimeOffset.UtcNow;
 
-    // Computed for backward compatibility: maps SRS stage to 0-100 scale
     public int Level => SrsStage == SrsStage.Burned ? 100 : (int)SrsStage * 100 / 9;
 
     public void AnswerCorrectly(DateTimeOffset? now = null)
     {
         SrsStage = SrsIntervals.Advance(SrsStage);
         NextReviewDate = SrsIntervals.GetNextReviewDate(SrsStage);
-        LastPracticed = now ?? DateTimeOffset.UtcNow;
+        LastPracticedAt = now ?? DateTimeOffset.UtcNow;
     }
 
     public void AnswerIncorrectly(DateTimeOffset? now = null)
     {
         SrsStage = SrsIntervals.Regress(SrsStage);
         NextReviewDate = SrsIntervals.GetNextReviewDate(SrsStage);
-        LastPracticed = now ?? DateTimeOffset.UtcNow;
+        LastPracticedAt = now ?? DateTimeOffset.UtcNow;
     }
 }

--- a/server/src/KanjiKa.Domain/Entities/Common/SrsStage.cs
+++ b/server/src/KanjiKa.Domain/Entities/Common/SrsStage.cs
@@ -1,4 +1,4 @@
-namespace KanjiKa.Domain.Entities.Kana;
+namespace KanjiKa.Domain.Entities.Common;
 
 public enum SrsStage
 {

--- a/server/src/KanjiKa.Domain/Entities/Grammar/GrammarProficiency.cs
+++ b/server/src/KanjiKa.Domain/Entities/Grammar/GrammarProficiency.cs
@@ -1,15 +1,11 @@
-using KanjiKa.Domain.Entities.Users;
+using KanjiKa.Domain.Entities.Common;
 
 namespace KanjiKa.Domain.Entities.Grammar;
 
-public class GrammarProficiency
+public class GrammarProficiency : Proficiency<GrammarPoint>
 {
-    public int Id { get; set; }
-    public int UserId { get; set; }
-    public User? User { get; set; }
     public int GrammarPointId { get; set; }
     public GrammarPoint? GrammarPoint { get; set; }
     public int CorrectCount { get; set; }
     public int AttemptCount { get; set; }
-    public DateTimeOffset LastPracticedAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/server/src/KanjiKa.Domain/Entities/Kana/KanaProficiency.cs
+++ b/server/src/KanjiKa.Domain/Entities/Kana/KanaProficiency.cs
@@ -1,0 +1,9 @@
+using KanjiKa.Domain.Entities.Common;
+
+namespace KanjiKa.Domain.Entities.Kana;
+
+public class KanaProficiency : Proficiency<Character>
+{
+    public int CharacterId { get; set; }
+    public Character? Character { get; set; }
+}

--- a/server/src/KanjiKa.Domain/Entities/Kanji/KanjiProficiency.cs
+++ b/server/src/KanjiKa.Domain/Entities/Kanji/KanjiProficiency.cs
@@ -1,28 +1,9 @@
-using KanjiKa.Domain.Entities.Kana;
-using KanjiKa.Domain.Entities.Users;
+using KanjiKa.Domain.Entities.Common;
 
 namespace KanjiKa.Domain.Entities.Kanji;
 
-public class KanjiProficiency
+public class KanjiProficiency : Proficiency<Kanji>
 {
-    public int Id { get; set; }
-    public int UserId { get; set; }
-    public User? User { get; set; }
     public int KanjiId { get; set; }
     public Kanji? Kanji { get; set; }
-    public SrsStage SrsStage { get; set; } = SrsStage.Apprentice1;
-    public DateTimeOffset? NextReviewDate { get; set; }
-    public DateTimeOffset LearnedAt { get; init; } = DateTimeOffset.UtcNow;
-
-    public void AnswerCorrectly()
-    {
-        SrsStage = SrsIntervals.Advance(SrsStage);
-        NextReviewDate = SrsIntervals.GetNextReviewDate(SrsStage);
-    }
-
-    public void AnswerIncorrectly()
-    {
-        SrsStage = SrsIntervals.Regress(SrsStage);
-        NextReviewDate = SrsIntervals.GetNextReviewDate(SrsStage);
-    }
 }

--- a/server/src/KanjiKa.Domain/Entities/Reading/ReadingProficiency.cs
+++ b/server/src/KanjiKa.Domain/Entities/Reading/ReadingProficiency.cs
@@ -1,16 +1,12 @@
-using KanjiKa.Domain.Entities.Users;
+using KanjiKa.Domain.Entities.Common;
 
 namespace KanjiKa.Domain.Entities.Reading;
 
-public class ReadingProficiency
+public class ReadingProficiency : Proficiency<ReadingPassage>
 {
-    public int Id { get; set; }
-    public int UserId { get; set; }
-    public User? User { get; set; }
     public int ReadingPassageId { get; set; }
     public ReadingPassage? ReadingPassage { get; set; }
     public int Score { get; set; }
     public int AttemptCount { get; set; }
     public bool IsPassed { get; set; }
-    public DateTimeOffset LastAttemptAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/server/src/KanjiKa.Domain/Entities/Users/User.cs
+++ b/server/src/KanjiKa.Domain/Entities/Users/User.cs
@@ -26,7 +26,7 @@ public class User
     public string? ActivationToken { get; set; }
     public DateTimeOffset? ActivationTokenExpiry { get; set; }
 
-    public List<Proficiency> Proficiencies { get; set; } = new();
+    public List<KanaProficiency> KanaProficiencies { get; set; } = new();
     public List<LessonCompletion> LessonCompletions { get; set; } = new();
     public UserSettings? Settings { get; set; }
 }

--- a/server/test/KanjiKa.UnitTests/Api/Services/AdminServiceTest.cs
+++ b/server/test/KanjiKa.UnitTests/Api/Services/AdminServiceTest.cs
@@ -1,6 +1,7 @@
 using KanjiKa.Application.Services;
 using KanjiKa.Application.DTOs;
 using KanjiKa.Application.DTOs.Admin;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Learning;
 using KanjiKa.Domain.Entities.Users;
@@ -117,14 +118,14 @@ public class AdminServiceTest
             PasswordSalt = [6],
             Role = UserRole.User,
             MustChangePassword = false,
-            Proficiencies = new List<Proficiency>
+            KanaProficiencies = new List<KanaProficiency>
             {
                 new()
                 {
                     CharacterId = 7,
                     Character = character,
                     LearnedAt = learnedAt,
-                    LastPracticed = lastPracticed
+                    LastPracticedAt = lastPracticed
                 }
             },
             LessonCompletions = new List<LessonCompletion>

--- a/server/test/KanjiKa.UnitTests/Api/Services/KanaServiceTest.cs
+++ b/server/test/KanjiKa.UnitTests/Api/Services/KanaServiceTest.cs
@@ -1,6 +1,7 @@
 using KanjiKa.Application.Services;
 using KanjiKa.Application.DTOs.Kana;
 using KanjiKa.Application.Interfaces;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Users;
 using Moq;
@@ -65,7 +66,7 @@ public class KanaServiceTest
         var repo = new Mock<IKanaRepository>();
         User user = MakeUser();
         Character character = MakeCharacter(1, "あ", "a", KanaType.Hiragana);
-        user.Proficiencies.Add(new Proficiency { CharacterId = 1, SrsStage = SrsStage.Guru1 });
+        user.KanaProficiencies.Add(new KanaProficiency { CharacterId = 1, SrsStage = SrsStage.Guru1 });
 
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.GetCharactersByType(KanaType.Hiragana)).Returns([character]);
@@ -75,7 +76,7 @@ public class KanaServiceTest
         IEnumerable<KanaDto> result = await service.GetKanaCharacters(KanaType.Hiragana, 1);
 
         KanaDto dto = result.Single();
-        Assert.Equal(new Proficiency { SrsStage = SrsStage.Guru1 }.Level, dto.Proficiency);
+        Assert.Equal(new KanaProficiency { SrsStage = SrsStage.Guru1 }.Level, dto.Proficiency);
     }
 
     [Fact]
@@ -154,7 +155,7 @@ public class KanaServiceTest
         var repo = new Mock<IKanaRepository>();
         Character character = MakeCharacter(1, "あ", "a", KanaType.Hiragana);
         User user = MakeUser();
-        user.Proficiencies.Add(new Proficiency { CharacterId = 1, SrsStage = SrsStage.Master });
+        user.KanaProficiencies.Add(new KanaProficiency { CharacterId = 1, SrsStage = SrsStage.Master });
         repo.Setup(r => r.GetCharacterBySymbolAndTypeAsync("あ", KanaType.Hiragana))
             .ReturnsAsync(character);
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);

--- a/server/test/KanjiKa.UnitTests/Api/Services/KanjiServiceTest.cs
+++ b/server/test/KanjiKa.UnitTests/Api/Services/KanjiServiceTest.cs
@@ -145,9 +145,9 @@ public class KanjiServiceTest
         var repo = new Mock<IKanjiRepository>();
         repo.Setup(r => r.GetDueReviewsAsync(1)).ReturnsAsync(
         [
-            new KanjiProficiency { UserId = 1, KanjiId = 1, SrsStage = Domain.Entities.Kana.SrsStage.Apprentice1 },
-            new KanjiProficiency { UserId = 1, KanjiId = 2, SrsStage = Domain.Entities.Kana.SrsStage.Apprentice2 },
-            new KanjiProficiency { UserId = 1, KanjiId = 3, SrsStage = Domain.Entities.Kana.SrsStage.Guru1 }
+            new KanjiProficiency { UserId = 1, KanjiId = 1, SrsStage = Domain.Entities.Common.SrsStage.Apprentice1 },
+            new KanjiProficiency { UserId = 1, KanjiId = 2, SrsStage = Domain.Entities.Common.SrsStage.Apprentice2 },
+            new KanjiProficiency { UserId = 1, KanjiId = 3, SrsStage = Domain.Entities.Common.SrsStage.Guru1 }
         ]);
         var service = new KanjiService(repo.Object);
 
@@ -182,12 +182,12 @@ public class KanjiServiceTest
         [
             new KanjiProficiency
             {
-                UserId = 1, KanjiId = 10, SrsStage = Domain.Entities.Kana.SrsStage.Apprentice1,
+                UserId = 1, KanjiId = 10, SrsStage = Domain.Entities.Common.SrsStage.Apprentice1,
                 Kanji = new Kanji { Id = 10, Character = "日", Meaning = "sun", OnyomiReading = "ニチ", KunyomiReading = "ひ", JlptLevel = 5, StrokeCount = 4 }
             },
             new KanjiProficiency
             {
-                UserId = 1, KanjiId = 20, SrsStage = Domain.Entities.Kana.SrsStage.Apprentice2,
+                UserId = 1, KanjiId = 20, SrsStage = Domain.Entities.Common.SrsStage.Apprentice2,
                 Kanji = new Kanji { Id = 20, Character = "月", Meaning = "moon", OnyomiReading = "ゲツ", KunyomiReading = "つき", JlptLevel = 5, StrokeCount = 4 }
             }
         ]);
@@ -223,7 +223,7 @@ public class KanjiServiceTest
 
         // Assert
         Assert.Multiple(
-            () => Assert.Equal(Domain.Entities.Kana.SrsStage.Apprentice1, result.SrsStage),
+            () => Assert.Equal(Domain.Entities.Common.SrsStage.Apprentice1, result.SrsStage),
             () => Assert.NotNull(result.NextReviewDate)
         );
         repo.Verify(expression: r => r.AddProficiencyAsync(It.IsAny<KanjiProficiency>()), Times.Once);
@@ -236,7 +236,7 @@ public class KanjiServiceTest
         // Arrange
         var repo = new Mock<IKanjiRepository>();
         repo.Setup(r => r.GetProficiencyAsync(1, 5))
-            .ReturnsAsync(new KanjiProficiency { UserId = 1, KanjiId = 5, SrsStage = Domain.Entities.Kana.SrsStage.Apprentice1 });
+            .ReturnsAsync(new KanjiProficiency { UserId = 1, KanjiId = 5, SrsStage = Domain.Entities.Common.SrsStage.Apprentice1 });
         var service = new KanjiService(repo.Object);
 
         // Act & Assert
@@ -248,7 +248,7 @@ public class KanjiServiceTest
     {
         // Arrange
         var repo = new Mock<IKanjiRepository>();
-        var proficiency = new KanjiProficiency { UserId = 1, KanjiId = 7, SrsStage = Domain.Entities.Kana.SrsStage.Apprentice1 };
+        var proficiency = new KanjiProficiency { UserId = 1, KanjiId = 7, SrsStage = Domain.Entities.Common.SrsStage.Apprentice1 };
         repo.Setup(r => r.GetProficiencyAsync(1, 7)).ReturnsAsync(proficiency);
         repo.Setup(r => r.SaveChangesAsync()).Returns(Task.CompletedTask);
         var service = new KanjiService(repo.Object);
@@ -260,7 +260,7 @@ public class KanjiServiceTest
         // Assert
         Assert.Multiple(
             () => Assert.True(result.IsCorrect),
-            () => Assert.Equal((int)Domain.Entities.Kana.SrsStage.Apprentice2, result.SrsStage)
+            () => Assert.Equal((int)Domain.Entities.Common.SrsStage.Apprentice2, result.SrsStage)
         );
     }
 
@@ -269,7 +269,7 @@ public class KanjiServiceTest
     {
         // Arrange
         var repo = new Mock<IKanjiRepository>();
-        var proficiency = new KanjiProficiency { UserId = 1, KanjiId = 7, SrsStage = Domain.Entities.Kana.SrsStage.Apprentice3 };
+        var proficiency = new KanjiProficiency { UserId = 1, KanjiId = 7, SrsStage = Domain.Entities.Common.SrsStage.Apprentice3 };
         repo.Setup(r => r.GetProficiencyAsync(1, 7)).ReturnsAsync(proficiency);
         repo.Setup(r => r.SaveChangesAsync()).Returns(Task.CompletedTask);
         var service = new KanjiService(repo.Object);
@@ -281,7 +281,7 @@ public class KanjiServiceTest
         // Assert
         Assert.Multiple(
             () => Assert.False(result.IsCorrect),
-            () => Assert.Equal((int)Domain.Entities.Kana.SrsStage.Apprentice1, result.SrsStage)
+            () => Assert.Equal((int)Domain.Entities.Common.SrsStage.Apprentice1, result.SrsStage)
         );
     }
 

--- a/server/test/KanjiKa.UnitTests/Api/Services/Lesson/GetLessonsAsyncTests.cs
+++ b/server/test/KanjiKa.UnitTests/Api/Services/Lesson/GetLessonsAsyncTests.cs
@@ -75,7 +75,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(completedToday);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act
@@ -101,7 +101,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act
@@ -130,7 +130,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync([]);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync([]);
         var service = new LessonService(repo.Object);
 
         // Act
@@ -151,7 +151,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act & Assert
@@ -170,7 +170,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act
@@ -193,7 +193,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act
@@ -233,7 +233,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act
@@ -254,7 +254,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act
@@ -280,7 +280,7 @@ public class GetLessonsAsyncTests
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetUserWithProficienciesAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.CountLessonsCompletedTodayAsync(1)).ReturnsAsync(0);
-        repo.Setup(r => r.GetNewCharactersAsync(user.Proficiencies)).ReturnsAsync(characters);
+        repo.Setup(r => r.GetNewCharactersAsync(user.KanaProficiencies)).ReturnsAsync(characters);
         var service = new LessonService(repo.Object);
 
         // Act

--- a/server/test/KanjiKa.UnitTests/Api/Services/Lesson/WritingReviewTests.cs
+++ b/server/test/KanjiKa.UnitTests/Api/Services/Lesson/WritingReviewTests.cs
@@ -1,5 +1,6 @@
 using KanjiKa.Application.Services;
 using KanjiKa.Application.DTOs.Learning;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Learning;
 using KanjiKa.Domain.Entities.Users;
@@ -15,7 +16,7 @@ public class WritingReviewTests
     {
         // Arrange
         const int userId = 1;
-        var dueReviews = new List<Proficiency>
+        var dueReviews = new List<KanaProficiency>
         {
             new() { UserId = userId, CharacterId = 1 },
             new() { UserId = userId, CharacterId = 2 },
@@ -38,7 +39,7 @@ public class WritingReviewTests
         // Arrange
         const int userId = 1;
         var repo = new Mock<ILessonRepository>();
-        repo.Setup(r => r.GetDueReviewsAsync(userId)).ReturnsAsync(new List<Proficiency>());
+        repo.Setup(r => r.GetDueReviewsAsync(userId)).ReturnsAsync(new List<KanaProficiency>());
         var service = new LessonService(repo.Object);
 
         // Act
@@ -54,7 +55,7 @@ public class WritingReviewTests
         // Arrange
         const int userId = 1;
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        var dueReviews = new List<Proficiency>
+        var dueReviews = new List<KanaProficiency>
         {
             new()
             {
@@ -90,7 +91,7 @@ public class WritingReviewTests
         // Arrange
         const int userId = 1;
         var repo = new Mock<ILessonRepository>();
-        repo.Setup(r => r.GetDueReviewsAsync(userId)).ReturnsAsync(new List<Proficiency>());
+        repo.Setup(r => r.GetDueReviewsAsync(userId)).ReturnsAsync(new List<KanaProficiency>());
         var service = new LessonService(repo.Object);
 
         // Act
@@ -105,7 +106,7 @@ public class WritingReviewTests
     {
         // Arrange
         var character = new Character { Id = 5, Symbol = "あ", Romanization = "a" };
-        var proficiency = new Proficiency { UserId = 1, CharacterId = 5, LearnedAt = DateTimeOffset.UtcNow };
+        var proficiency = new KanaProficiency { UserId = 1, CharacterId = 5, LearnedAt = DateTimeOffset.UtcNow };
 
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetCharacterByIdAsync(5)).ReturnsAsync(character);
@@ -128,7 +129,7 @@ public class WritingReviewTests
     {
         // Arrange
         var character = new Character { Id = 5, Symbol = "あ", Romanization = "a" };
-        var proficiency = new Proficiency { UserId = 1, CharacterId = 5, SrsStage = SrsStage.Guru1, LearnedAt = DateTimeOffset.UtcNow };
+        var proficiency = new KanaProficiency { UserId = 1, CharacterId = 5, SrsStage = SrsStage.Guru1, LearnedAt = DateTimeOffset.UtcNow };
 
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetCharacterByIdAsync(5)).ReturnsAsync(character);
@@ -167,7 +168,7 @@ public class WritingReviewTests
 
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetCharacterByIdAsync(5)).ReturnsAsync(character);
-        repo.Setup(r => r.GetProficiencyAsync(1, 5)).ReturnsAsync((Proficiency?)null);
+        repo.Setup(r => r.GetProficiencyAsync(1, 5)).ReturnsAsync((KanaProficiency?)null);
         var service = new LessonService(repo.Object);
 
         // Act & Assert

--- a/server/test/KanjiKa.UnitTests/Api/Services/LessonServiceTest.cs
+++ b/server/test/KanjiKa.UnitTests/Api/Services/LessonServiceTest.cs
@@ -1,5 +1,6 @@
 using KanjiKa.Application.Services;
 using KanjiKa.Application.DTOs.Learning;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Learning;
 using KanjiKa.Domain.Entities.Users;
@@ -20,14 +21,14 @@ public class LessonServiceTest
         var repo = new Mock<ILessonRepository>(MockBehavior.Strict);
         repo.Setup(r => r.GetUserAsync(1)).ReturnsAsync(user);
         repo.Setup(r => r.GetCharacterByIdAsync(10)).ReturnsAsync(character);
-        repo.Setup(r => r.GetProficiencyAsync(1, 10)).ReturnsAsync((Proficiency?)null);
-        repo.Setup(r => r.AddProficiencyAsync(It.IsAny<Proficiency>())).Returns(Task.CompletedTask).Verifiable();
+        repo.Setup(r => r.GetProficiencyAsync(1, 10)).ReturnsAsync((KanaProficiency?)null);
+        repo.Setup(r => r.AddProficiencyAsync(It.IsAny<KanaProficiency>())).Returns(Task.CompletedTask).Verifiable();
         repo.Setup(r => r.AddLessonCompletionAsync(It.IsAny<LessonCompletion>())).Returns(Task.CompletedTask).Verifiable();
         repo.Setup(r => r.SaveChangesAsync()).Returns(Task.CompletedTask).Verifiable();
         var service = new LessonService(repo.Object);
 
         // Act
-        Proficiency proficiency = await service.LearnLessonAsync(1, 10);
+        KanaProficiency proficiency = await service.LearnLessonAsync(1, 10);
 
         // Assert
         Assert.Equal(1, proficiency.UserId);
@@ -42,7 +43,7 @@ public class LessonServiceTest
     {
         // Arrange
         const int userId = 1;
-        var dueReviews = new List<Proficiency>
+        var dueReviews = new List<KanaProficiency>
         {
             new() { UserId = userId, CharacterId = 1 },
             new() { UserId = userId, CharacterId = 2 },
@@ -65,7 +66,7 @@ public class LessonServiceTest
         // Arrange
         const int userId = 1;
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        var dueReviews = new List<Proficiency>
+        var dueReviews = new List<KanaProficiency>
         {
             new()
             {
@@ -100,7 +101,7 @@ public class LessonServiceTest
     {
         var user = new User { Id = 1, Username = "user", PasswordHash = [0], PasswordSalt = [0] };
         var character = new Character { Id = 2, Symbol = "ら", Romanization = "ra" };
-        var proficiency = new Proficiency { UserId = user.Id, CharacterId = 2, LearnedAt = DateTimeOffset.UtcNow };
+        var proficiency = new KanaProficiency { UserId = user.Id, CharacterId = 2, LearnedAt = DateTimeOffset.UtcNow };
 
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetCharacterBySymbolAsync("ら")).ReturnsAsync(character);
@@ -122,7 +123,7 @@ public class LessonServiceTest
     {
         // Arrange
         var character = new Character { Id = 2, Symbol = "ら", Romanization = "ra" };
-        var proficiency = new Proficiency { UserId = 1, CharacterId = 2, SrsStage = SrsStage.Guru1, LearnedAt = DateTimeOffset.UtcNow };
+        var proficiency = new KanaProficiency { UserId = 1, CharacterId = 2, SrsStage = SrsStage.Guru1, LearnedAt = DateTimeOffset.UtcNow };
 
         var repo = new Mock<ILessonRepository>();
         repo.Setup(r => r.GetCharacterBySymbolAsync("ら")).ReturnsAsync(character);

--- a/server/test/KanjiKa.UnitTests/Core/DTOs/Kana/KanaDetailDtoTest.cs
+++ b/server/test/KanjiKa.UnitTests/Core/DTOs/Kana/KanaDetailDtoTest.cs
@@ -1,4 +1,5 @@
 using KanjiKa.Application.DTOs.Kana;
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 
 namespace KanjiKa.UnitTests.Core.DTOs.Kana;

--- a/server/test/KanjiKa.UnitTests/Core/Entities/Kana/ProficiencyTest.cs
+++ b/server/test/KanjiKa.UnitTests/Core/Entities/Kana/ProficiencyTest.cs
@@ -1,3 +1,4 @@
+using KanjiKa.Domain.Entities.Common;
 using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Learning;
 using KanjiKa.Domain.Entities.Users;
@@ -38,7 +39,7 @@ public class ProficiencyTest
         user.LessonCompletions.Add(lessonCompletion);
 
         // Act
-        var proficiency = new Proficiency
+        var proficiency = new KanaProficiency
         {
             Id = 1,
             UserId = userId,
@@ -47,7 +48,7 @@ public class ProficiencyTest
             Character = character,
             SrsStage = SrsStage.Guru1,
             LearnedAt = now,
-            LastPracticed = now
+            LastPracticedAt = now
         };
 
         // Assert
@@ -59,7 +60,7 @@ public class ProficiencyTest
             () => Assert.Equal(character, proficiency.Character),
             () => Assert.Equal(SrsStage.Guru1, proficiency.SrsStage),
             () => Assert.Equal(now, proficiency.LearnedAt),
-            () => Assert.Equal(now, proficiency.LastPracticed)
+            () => Assert.Equal(now, proficiency.LastPracticedAt)
         );
     }
 
@@ -67,7 +68,7 @@ public class ProficiencyTest
     public void AnswerCorrectly_AdvancesStage()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Apprentice1 };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Apprentice1 };
 
         // Act
         proficiency.AnswerCorrectly();
@@ -80,7 +81,7 @@ public class ProficiencyTest
     public void AnswerCorrectly_FromBurned_StaysAtBurned()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Burned };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Burned };
 
         // Act
         proficiency.AnswerCorrectly();
@@ -93,7 +94,7 @@ public class ProficiencyTest
     public void AnswerCorrectly_SetsNextReviewDate()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Apprentice1 };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Apprentice1 };
 
         // Act
         proficiency.AnswerCorrectly();
@@ -107,7 +108,7 @@ public class ProficiencyTest
     {
         // Arrange
         // Guru1 = 5, regress by 2 → stage 3 = Apprentice3
-        var proficiency = new Proficiency { SrsStage = SrsStage.Guru1 };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Guru1 };
 
         // Act
         proficiency.AnswerIncorrectly();
@@ -120,7 +121,7 @@ public class ProficiencyTest
     public void AnswerIncorrectly_CannotGoBelowApprentice1()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Apprentice1 };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Apprentice1 };
 
         // Act
         proficiency.AnswerIncorrectly();
@@ -133,7 +134,7 @@ public class ProficiencyTest
     public void AnswerIncorrectly_SetsNextReviewDate()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Guru2 };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Guru2 };
 
         // Act
         proficiency.AnswerIncorrectly();
@@ -146,7 +147,7 @@ public class ProficiencyTest
     public void Level_MapsCorrectly_ForApprentice1()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Apprentice1 };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Apprentice1 };
 
         // Act
         int level = proficiency.Level;
@@ -160,7 +161,7 @@ public class ProficiencyTest
     public void Level_Is100_WhenBurned()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Burned };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Burned };
 
         // Act
         int level = proficiency.Level;
@@ -173,7 +174,7 @@ public class ProficiencyTest
     public void Proficiency_Level_ShouldLockedReturnZero()
     {
         // Arrange
-        var proficiency = new Proficiency { SrsStage = SrsStage.Locked };
+        var proficiency = new KanaProficiency { SrsStage = SrsStage.Locked };
 
         // Act + Assert
         Assert.Equal(0, proficiency.Level);
@@ -184,17 +185,17 @@ public class ProficiencyTest
     {
         // Arrange
         var fixedNow = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        var proficiency = new Proficiency
+        var proficiency = new KanaProficiency
         {
             SrsStage = SrsStage.Apprentice2,
-            LastPracticed = fixedNow.AddHours(-1)
+            LastPracticedAt = fixedNow.AddHours(-1)
         };
 
         // Act
         proficiency.AnswerCorrectly(fixedNow);
 
         // Assert
-        Assert.Equal(fixedNow, proficiency.LastPracticed);
+        Assert.Equal(fixedNow, proficiency.LastPracticedAt);
     }
 
     [Fact]
@@ -202,16 +203,16 @@ public class ProficiencyTest
     {
         // Arrange
         var fixedNow = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        var proficiency = new Proficiency
+        var proficiency = new KanaProficiency
         {
             SrsStage = SrsStage.Guru2,
-            LastPracticed = fixedNow.AddHours(-1)
+            LastPracticedAt = fixedNow.AddHours(-1)
         };
 
         // Act
         proficiency.AnswerIncorrectly(fixedNow);
 
         // Assert
-        Assert.Equal(fixedNow, proficiency.LastPracticed);
+        Assert.Equal(fixedNow, proficiency.LastPracticedAt);
     }
 }

--- a/server/test/KanjiKa.UnitTests/Core/Entities/Kana/SrsIntervalsTest.cs
+++ b/server/test/KanjiKa.UnitTests/Core/Entities/Kana/SrsIntervalsTest.cs
@@ -1,4 +1,4 @@
-using KanjiKa.Domain.Entities.Kana;
+using KanjiKa.Domain.Entities.Common;
 
 namespace KanjiKa.UnitTests.Core.Entities.Kana;
 

--- a/server/test/KanjiKa.UnitTests/Core/Entities/Users/UserTest.cs
+++ b/server/test/KanjiKa.UnitTests/Core/Entities/Users/UserTest.cs
@@ -1,4 +1,4 @@
-﻿using KanjiKa.Domain.Entities.Kana;
+using KanjiKa.Domain.Entities.Kana;
 using KanjiKa.Domain.Entities.Learning;
 using KanjiKa.Domain.Entities.Users;
 
@@ -17,7 +17,7 @@ public class UserTest
             Username = "testUser",
             PasswordHash = hashBytes,
             PasswordSalt = saltBytes,
-            Proficiencies = new List<Proficiency>(),
+            KanaProficiencies = new List<KanaProficiency>(),
             LessonCompletions = new List<LessonCompletion>()
         };
 
@@ -26,8 +26,8 @@ public class UserTest
             () => Assert.Equal("testUser", user.Username),
             () => Assert.Equal(hashBytes, user.PasswordHash),
             () => Assert.Equal(saltBytes, user.PasswordSalt),
-            () => Assert.NotNull(user.Proficiencies),
-            () => Assert.Empty(user.Proficiencies),
+            () => Assert.NotNull(user.KanaProficiencies),
+            () => Assert.Empty(user.KanaProficiencies),
             () => Assert.NotNull(user.LessonCompletions),
             () => Assert.Empty(user.LessonCompletions)
         );


### PR DESCRIPTION
## Summary

- Introduces `Proficiency<TContent>` abstract generic base class in `KanjiKa.Domain.Entities.Common`, shared by all four proficiency types
- All four concrete types (`KanaProficiency`, `KanjiProficiency`, `GrammarProficiency`, `ReadingProficiency`) now inherit SRS fields (`SrsStage`, `NextReviewDate`, `LearnedAt`), unified `LastPracticedAt` timestamp, `Level` property, and `AnswerCorrectly/Incorrectly` methods from the base
- Moves `SrsStage` enum and `SrsIntervals` from `Kana` namespace to `Common` namespace since Kanji also depends on them
- Renames `Proficiency` (Kana entity) → `KanaProficiency` to remove ambiguity with the base class
- Standardizes the last-practiced timestamp to `LastPracticedAt` across all entities (was `LastPracticed` for Kana, `LastAttemptAt` for Reading, missing for Kanji)
- Adds migration `UnifyProficiencyHierarchy`: replaces composite-PK `proficiencies` table with `kana_proficiencies` (auto-increment PK + unique index on user+character), adds SRS columns to grammar and reading proficiency tables, adds `last_practiced_at` to kanji proficiencies

## Test plan

- [ ] All 214 backend unit tests pass (`dotnet test`)
- [ ] Build succeeds in Release configuration (`dotnet build --configuration Release`)
- [ ] Migration applies cleanly to a fresh dev database (`dotnet ef database update`)
- [ ] Hiragana/Katakana lesson and review flows work end-to-end
- [ ] Kanji review flow works end-to-end
- [ ] Grammar exercise flow works end-to-end
- [ ] Reading passage submission works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)